### PR TITLE
PD-14-3 Развернуть proto-файл с помощью gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'com.google.protobuf' version "0.9.4"
 }
 
 group = 'wavesDRSN'
@@ -23,13 +24,48 @@ repositories {
 	mavenCentral()
 }
 
+def grpcVersion = '1.71.0'
+def protobufVersion = '3.25.5'
+def protocVersion = protobufVersion
+
+protobuf {
+	protoc { artifact = "com.google.protobuf:protoc:${protocVersion}" }
+	plugins {
+		grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
+	}
+	generateProtoTasks {
+		all()*.plugins { grpc {} }
+	}
+}
+
 dependencies {
+	implementation "io.grpc:grpc-protobuf:${grpcVersion}"
+	implementation "io.grpc:grpc-services:${grpcVersion}"
+	implementation "io.grpc:grpc-stub:${grpcVersion}"
+	compileOnly "org.apache.tomcat:annotations-api:6.0.53"
+
+	runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
+
+	testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+	testImplementation "io.grpc:grpc-inprocess:${grpcVersion}"
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+
+
+sourceSets {
+	main {
+		java {
+			srcDirs 'build/generated/source/proto/main/grpc'
+			srcDirs 'build/generated/source/proto/main/java'
+		}
+	}
 }
 
 tasks.named('test') {


### PR DESCRIPTION
Настроил Gradle на версию grpc 1.71.0. Она развернул сервисы и описанную структуру proto-файла